### PR TITLE
Assembly support

### DIFF
--- a/my-common-code/api2.S
+++ b/my-common-code/api2.S
@@ -1,0 +1,32 @@
+/*
+
+  Simple assembly demo
+
+  To remove it, just remove api2.c, api2.h and all api2/my_func2
+  remnants from my-project.c and Makefile.
+
+*/
+
+#include <libopencm3/stm32/gpio.h>
+
+.syntax unified
+.cpu cortex-m4
+.thumb
+.section .text
+
+.global my_func2
+.type my_func2,%function
+my_func2:
+.fnstart
+  ldr r1, = GPIOA
+  // store input to GPIOA
+  str r0, [r1, # GPIO_ODR(0)]
+  // load from GPIOA
+  ldr r0, [r1, # GPIO_IDR(0)]
+
+  // store bit 0 to bit 6 of GPIOB6
+  ldr r1, = BBIO_PERIPH(GPIO_ODR(GPIOB), 6)
+  str r0, [r1]
+
+  bx lr
+.fnend

--- a/my-common-code/api2.h
+++ b/my-common-code/api2.h
@@ -1,0 +1,1 @@
+int my_func2(int a);

--- a/my-project/Makefile
+++ b/my-project/Makefile
@@ -2,8 +2,8 @@ PROJECT = awesomesauce
 BUILD_DIR = bin
 
 SHARED_DIR = ../my-common-code
-CFILES = my-project.c
-CFILES += api.c
+OFILES = my-project.o
+OFILES += api.o
 
 # TODO - you will need to edit these two lines!
 DEVICE=stm32f407vgt6

--- a/my-project/Makefile
+++ b/my-project/Makefile
@@ -4,6 +4,7 @@ BUILD_DIR = bin
 SHARED_DIR = ../my-common-code
 OFILES = my-project.o
 OFILES += api.o
+OFILES += api2.o
 
 # TODO - you will need to edit these two lines!
 DEVICE=stm32f407vgt6

--- a/my-project/my-project.c
+++ b/my-project/my-project.c
@@ -1,6 +1,8 @@
 #include "api.h"
+#include "api2.h"
 
 int main(void) {
 	/* add your own code */
-	return my_func(3);
+	int a = my_func(3);
+	return my_func2(a);
 }

--- a/rules.mk
+++ b/rules.mk
@@ -124,6 +124,11 @@ $(BUILD_DIR)/%.o: %.c
 	@mkdir -p $(dir $@)
 	$(Q)$(CC) $(TGT_CFLAGS) $(CFLAGS) $(TGT_CPPFLAGS) $(CPPFLAGS) -o $@ -c $<
 
+$(BUILD_DIR)/%.o: %.S
+	@printf "  CC\t$<\n"
+	@mkdir -p $(dir $@)
+	$(Q)$(CC) $(TGT_CFLAGS) $(CFLAGS) $(TGT_CPPFLAGS) $(CPPFLAGS) -o $@ -c $<
+
 $(BUILD_DIR)/%.o: %.cxx
 	@printf "  CXX\t$<\n"
 	@mkdir -p $(dir $@)

--- a/rules.mk
+++ b/rules.mk
@@ -55,7 +55,7 @@ OPENCM3_INC = $(OPENCM3_DIR)/include
 # Inclusion of library header files
 INCLUDES += $(patsubst %,-I%, . $(OPENCM3_INC) )
 
-OBJS = $(CFILES:%.c=$(BUILD_DIR)/%.o)
+OBJS = $(OFILES:%.o=$(BUILD_DIR)/%.o)
 GENERATED_BINS = $(PROJECT).elf $(PROJECT).bin $(PROJECT).map $(PROJECT).list $(PROJECT).lss
 
 TGT_CPPFLAGS += -MD


### PR DESCRIPTION
This PR only work with https://github.com/libopencm3/libopencm3/pull/981 merged.

The change from CFILES to OFILES is one way to go, the other would be to add "AFILES" and merge them into the OBJS. But since the source extension is not required anyway this seemed simpler.

A simple assembly demo is added as well as all required changes to compile it.