### PR TITLE
Mention about python command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Easy "clone and go" repository for a libopencm3 based project.
 If you have an older git, or got ahead of yourself and skipped the ```--recurse-submodules```
 you can fix things by running ```git submodule update --init``` (This is only needed once)
 
+On some linux distributions like Ubuntu, you need to make sure `python` points to `python3` for the `make` command to work.
+On debian based distributions, this can be done by running `sudo apt install python-is-python3`.
+
 # Directories
 * my-project contains your application
 * my-common-code contains something shared.


### PR DESCRIPTION
On Ubuntu, the python command isn't found by default, so the make commands will fail. Mention pointing python to python3 to solve common build problem.